### PR TITLE
Fix deploying docs to GH pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,11 @@ jobs:
 
       - name: Deploy documentation
         if: success()
-        uses: crazy-max/ghaction-github-pages@v1
+        uses: crazy-max/ghaction-github-pages@v2
         with:
           build_dir: target/doc
+          target_branch: gh-pages
         env:
-          GITHUB_PAT: ${{ secrets.THOM_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 #  vim: set ft=yaml ts=2 sw=2 tw=0 et :

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Contents
 --------
 
 This crate provides unsafe `ffi` bindings in the `oqs-sys` crate, and safe wrappers are offered via the `oqs` crate.
+The rendered rustdoc documentation can be [found here](https://open-quantum-safe.github.io/liboqs-rust/)
 
 Usage
 -----


### PR DESCRIPTION
It's now able to use GITHUB_TOKEN which is available by default AIUI.