### PR TITLE
Ensure Clang is present before attempting to compile liboqs

### DIFF
--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -36,6 +36,9 @@ fn generate_bindings(outdir: &PathBuf, headerfile: &str, filter: &str) {
 }
 
 fn main() {
+    // Check if clang is available before compiling anything.
+    bindgen::clang_version();
+
     let mut config = cmake::Config::new("liboqs");
     config.profile("Release");
     config.define("OQS_BUILD_ONLY_LIB", "Yes");


### PR DESCRIPTION
For those running a system that (tragically) only has gcc based toolchains by default, this speeds up the compilation failure that tells you `libclang` is missing:

```
Compiling oqs-sys v0.3.0 (/liboqs-rust/oqs-sys)
error: failed to run custom build command for `oqs-sys v0.3.0 (/liboqs-rust/oqs-sys)`

Caused by:
  process didn't exit successfully: `liboqs-rust/target/debug/build/oqs-sys-17a5bc04ec449e4a/build-script-build` (exit code: 101)
  --- stderr
  thread 'main' panicked at 'Unable to find libclang: "couldn\'t find any valid shared libraries matching: [\'libclang.so\', \'libclang-*.so\', \'libclang.so.*\', \'libclang-*.so.*\'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /home/fox/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.55.1/src/lib.rs:1896:31
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  ```

This is better, imo, to waiting to compile all of `liboqs` only for bindgen to kill it.

Before: `348.19s user 361.48s system 1156% cpu 1:01.38 total`
After: `49.22s user 17.09s system 365% cpu 18.119 total`
