### PR TITLE
Bump the version number for next release

### DIFF
--- a/oqs-sys/Cargo.toml
+++ b/oqs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oqs-sys"
-version = "0.3.0"
+version = "0.5.0"
 authors = ["Thom Wiggers <thom@thomwiggers.nl>"]
 edition = "2018"
 links = "oqs"

--- a/oqs/Cargo.toml
+++ b/oqs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oqs"
-version = "0.3.0"
+version = "0.5.0"
 authors = ["Thom Wiggers <thom@thomwiggers.nl>"]
 edition = "2018"
 description = "A Rusty interface to Open-Quantum-Safe's liboqs"
@@ -16,7 +16,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 
 [dependencies.oqs-sys]
 path = "../oqs-sys"
-version = "0.3.0"
+version = "0.5.0"
 default-features = false
 
 [features]


### PR DESCRIPTION
We won't publish before liboqs 0.5 though.