### PR TITLE
Expose random API

### DIFF
--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -95,6 +95,7 @@ fn main() {
     let gen_bindings = |file, filter| generate_bindings(&outdir, file, filter);
 
     gen_bindings("common", "OQS_.*");
+    gen_bindings("rand", "OQS_(randombytes|RAND)_.*");
     gen_bindings("kem", "OQS_KEM.*");
     gen_bindings("sig", "OQS_SIG.*");
 

--- a/oqs-sys/src/lib.rs
+++ b/oqs-sys/src/lib.rs
@@ -13,6 +13,15 @@ pub mod common {
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
+pub mod rand {
+    pub use super::common::OQS_STATUS;
+    include!(concat!(env!("OUT_DIR"), "/rand_bindings.rs"));
+}
+
+#[allow(clippy::all)]
+#[allow(non_upper_case_globals)]
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
 pub mod kem {
     pub use super::common::OQS_STATUS;
     include!(concat!(env!("OUT_DIR"), "/kem_bindings.rs"));


### PR DESCRIPTION
Generate bindings to the random API exposed by liboqs (ie. https://github.com/open-quantum-safe/liboqs/blob/main/src/common/rand/rand.h)