### PR TITLE
Replace no_std feature with a std feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,23 +71,23 @@ jobs:
         with:
           command: test
 
+      - name: Cargo test --no-default-features --features serde,kems,sigs,std
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: --no-default-features --features serde,kems,sigs,std --manifest-path oqs/Cargo.toml
+
       - name: Cargo test --no-default-features --features serde,kems,sigs
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
           args: --no-default-features --features serde,kems,sigs --manifest-path oqs/Cargo.toml
 
-      - name: Cargo test --no-default-features --features serde,no_std,kems,sigs
+      - name: Cargo test --no-default-features --features non_portable,kems,sigs,std
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --no-default-features --features no_std,serde,kems,sigs --manifest-path oqs/Cargo.toml
-
-      - name: Cargo test --no-default-features --features non_portable,kems,sigs
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: --no-default-features --features non_portable,kems,sigs --manifest-path oqs/Cargo.toml
+          args: --no-default-features --features non_portable,kems,sigs,std --manifest-path oqs/Cargo.toml
 
       - name: Cargo fmt
         uses: actions-rs/cargo@v1.0.3

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Serde support
 
 You can enable ``serde`` serialization support by enabling the ``serde`` feature on the ``oqs`` crate.
 
-``no_std`` support
+``std`` support
 ----------------
 
 The ``oqs-sys`` crate does not use `std` at all.
 Note that the default features do enable building liboqs with ``openssl``, so use ``default-features = false``.
 
-For ``no_std`` suport in the ``oqs`` crate, enable the ``no_std`` feature.
+To make ``oqs`` a ``#![no_std]`` crate make sure the ``std`` feature is disabled.
 Make sure to also disable the ``oqs-sys/openssl`` feature by specifying ``default-features = false``.
 
 As `default-features` includes the `kems` and `sigs` features, consider re-adding them as well. This results into:
@@ -58,7 +58,7 @@ As `default-features` includes the `kems` and `sigs` features, consider re-addin
 [dependencies.oqs]
 version = "*"
 default-features = false
-features = ["no_std", "sigs", "kems"]
+features = ["sigs", "kems"]
 ```
 
 You will probably want to change the random-number generator through the [`OQS_RAND` API][] offered by `oqs-sys`.

--- a/oqs/Cargo.toml
+++ b/oqs/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 libc = "0.2"
-cstr_core = { version = "0.2", default-features = false, features = ["alloc"], optional = true }
+cstr_core = { version = "0.2", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive", "alloc"] }
 
 [dependencies.oqs-sys]
@@ -20,8 +20,8 @@ version = "0.7.0"
 default-features = false
 
 [features]
-default = ["oqs-sys/openssl", "kems", "sigs"]
-no_std = ["cstr_core"]
+default = ["oqs-sys/openssl", "kems", "sigs", "std"]
+std = []
 non_portable = ["oqs-sys/non_portable"]
 
 # algorithms: KEMs

--- a/oqs/README.md
+++ b/oqs/README.md
@@ -7,8 +7,9 @@ For the ``ffi`` interface bindings, see ``oqs-sys``.
 
 ## Features
 
-* `no_std`: build without `std` support (probably want to disable the default
-  features because they pull in OpenSSL through `oqs-sys`).
+* `std`: build with `std` support. This adds handly `Display` and `Error` implementations
+  to relevant types. If you want a `#![no_std]` library, disable this feature (and you
+  probably want to disable the default features because they pull in OpenSSL through `oqs-sys`).
 * `non_portable`: Don't build a portable library.
 * `kems` (default): Compile with all KEMs enabled
     * `bike`  (only on non-Windows)

--- a/oqs/src/kem.rs
+++ b/oqs/src/kem.rs
@@ -7,9 +7,9 @@ use alloc::vec::Vec;
 
 use core::ptr::NonNull;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use cstr_core::CStr;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::ffi::CStr;
 
 #[cfg(feature = "serde")]
@@ -80,11 +80,13 @@ macro_rules! implement_kems {
                     }
                 }
 
-                #[cfg(not(feature = "no_std"))]
                 #[test]
-                fn test_display() {
-                    // Just make sure the Display impl does not panic or crash.
-                    let name = Algorithm::$kem.to_string();
+                fn test_name() {
+                    let algo = Algorithm::$kem;
+                    // Just make sure the name impl does not panic or crash.
+                    let name = algo.name();
+                    #[cfg(feature = "std")]
+                    assert_eq!(name, algo.to_string());
                     // ... And actually contains something.
                     assert!(!name.is_empty());
                 }
@@ -171,7 +173,6 @@ impl Algorithm {
     /// Returns the algorithm's name as a static Rust string.
     ///
     /// This is the same as the `to_id`, but as a safe Rust string.
-    #[cfg(not(feature = "no_std"))]
     pub fn name(&self) -> &'static str {
         // SAFETY: The id from ffi must be a proper null terminated C string
         let id = unsafe { CStr::from_ptr(self.to_id()) };
@@ -179,7 +180,7 @@ impl Algorithm {
     }
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl std::fmt::Display for Algorithm {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.name().fmt(f)

--- a/oqs/src/lib.rs
+++ b/oqs/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 //! Friendly bindings to liboqs
 //!
 //! See the [`kem::Kem`](crate::kem::Kem) and [`sig::Sig`](crate::sig::Sig) structs for how to use this crate.
@@ -44,9 +44,6 @@
 // needs to be imported to be made available
 extern crate alloc;
 
-#[cfg(not(feature = "no_std"))]
-use std::sync::Once;
-
 use ffi::common::OQS_STATUS;
 
 /// Access the OQS ffi through this crate.
@@ -58,10 +55,11 @@ mod macros;
 ///
 /// Make sure to call this before you use any of the functions.
 ///
-/// When the ``no_std`` feature is not enabled, this method is thread-safe
+/// When the ``std`` feature is enabled, this method is thread-safe
 /// and can be called more than once.
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 pub fn init() {
+    use std::sync::Once;
     static INIT: Once = Once::new();
     INIT.call_once(|| {
         unsafe { ffi::common::OQS_init() };
@@ -73,7 +71,7 @@ pub fn init() {
 /// Needs to be called before you use any of the functions.
 ///
 /// This ``no_std`` variant is not thread-safe.
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 pub fn init() {
     unsafe { ffi::common::OQS_init() };
 }
@@ -92,7 +90,7 @@ pub enum Error {
     /// Invalid length of a public object
     InvalidLength,
 }
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 /// Result type for operations that may fail

--- a/oqs/src/sig.rs
+++ b/oqs/src/sig.rs
@@ -7,9 +7,9 @@ use alloc::vec::Vec;
 
 use core::ptr::NonNull;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use cstr_core::CStr;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::ffi::CStr;
 
 use crate::ffi::sig as ffi;
@@ -78,11 +78,15 @@ macro_rules! implement_sigs {
                     }
                 }
 
-                #[cfg(not(feature = "no_std"))]
                 #[test]
-                fn test_display() {
-                    // Just make sure the Display impl does not panic or crash.
-                    let name = Algorithm::$sig.to_string();
+                fn test_name() {
+                    let algo = Algorithm::$sig;
+                    // Just make sure the name impl does not panic or crash.
+                    let name = algo.name();
+
+                    #[cfg(feature = "std")]
+                    assert_eq!(name, algo.to_string());
+
                     // ... And actually contains something.
                     assert!(!name.is_empty());
                 }
@@ -173,7 +177,6 @@ impl Algorithm {
     /// Returns the algorithm's name as a static Rust string.
     ///
     /// This is the same as the `to_id`, but as a safe Rust string.
-    #[cfg(not(feature = "no_std"))]
     pub fn name(&self) -> &'static str {
         // SAFETY: The id from ffi must be a proper null terminated C string
         let id = unsafe { CStr::from_ptr(self.to_id()) };
@@ -207,7 +210,7 @@ impl Drop for Sig {
     }
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl std::fmt::Display for Algorithm {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.name().fmt(f)


### PR DESCRIPTION
Features should be **additive**. Activating a feature should only add functionality. Please see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification

> A consequence of this is that features should be additive. That is, enabling a feature should not disable functionality, ...
> For example, if you want to optionally support no_std environments, do not use a no_std feature. Instead, use a std feature that enables std. For example:

So I went ahead and inverted the existing feature into the more idiomatic additive version.

One downside currently is that the `cstr_core` crate is being pulled in in the `std` builds that does not need them. But I don't think that's a huge downside. Can maybe me cleaned up? Suggestions?

Changing the features like this is a breaking change. So I wanted to get this PR submitted before version 0.8 is being made.