### PR TITLE
Release liboqs 0.7.1

### DIFF
--- a/oqs-sys/Cargo.toml
+++ b/oqs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oqs-sys"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Thom Wiggers <thom@thomwiggers.nl>"]
 edition = "2018"
 links = "oqs"

--- a/oqs/Cargo.toml
+++ b/oqs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oqs"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Thom Wiggers <thom@thomwiggers.nl>"]
 edition = "2018"
 description = "A Rusty interface to Open-Quantum-Safe's liboqs"
@@ -16,7 +16,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 
 [dependencies.oqs-sys]
 path = "../oqs-sys"
-version = "0.7.0"
+version = "0.7.1"
 default-features = false
 
 [features]


### PR DESCRIPTION
# Changes since liboqs-rs 0.7.0

* NTRU level 5 algorithms
* NTRUPrime level 5 algorithms
* Be able to extract Algorithm from Sig/Kem
* Invert no_std feature (breaking, sorry!)
* Implement Display, Hash, Eq for Kem, Sig
* Implement Display for Algorithm

## Changes from liboqs

### KEMs

* Add NTRU level 5 parameter sets (ntruhps40961229, ntruhrss1373)
* Add NTRU Prime level 5 parameter sets (ntrulpr1277, sntrup1277)
* Add ARMv8 aarch64 optimized implementations of Kyber and SABER
* Minor updates to Kyber, NTRU, NTRU Prime, and SIKE implementations

### Digital signature schemes

* Minor updates to Dilithium implementation

### Other changes

* Optimized AES implementation on ARMv8 with crypto extensions.
* Preliminary support for building on S390x platform
* Improved build configurations on ARM platforms
* Improvements to benchmarking harness, with improved precision on ARM platforms

See also https://github.com/open-quantum-safe/liboqs/releases/tag/0.7.1
