### PR TITLE
Update sig.rs

### DIFF
--- a/oqs/src/sig.rs
+++ b/oqs/src/sig.rs
@@ -47,7 +47,7 @@ macro_rules! implement_sigs {
                     Algorithm::$sig => &ffi::$oqs_id[..],
                 )*
             };
-            id as *const _ as *const i8
+            id as *const _ as *const libc::c_char
         }
 
         $(


### PR DESCRIPTION
Type should match function definition, otherwise this won't compile on platforms regardless of them defining c_char as i8 or u8. Likewise for kem.rs