### PR TITLE
Update kem.rs

### DIFF
--- a/oqs/src/kem.rs
+++ b/oqs/src/kem.rs
@@ -46,7 +46,7 @@ macro_rules! implement_kems {
                     Algorithm::$kem => &ffi::$oqs_id[..],
                 )*
             };
-            id as *const _ as *const i8
+            id as *const _ as *const libc::c_char
         }
 
         $(


### PR DESCRIPTION
These types should match so they compile either on platforms that define char as i8 or u8. Likewise for sig.rs (raised as separate pull request).