### PR TITLE
Don't update Rustup in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Install Rust
         run: |
+          rustup set auto-self-update disable
           rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt --component clippy
           rustup default ${{ matrix.rust }}
           echo CARGO_TERM_COLOR=always >> $GITHUB_ENV


### PR DESCRIPTION
This avoids https://github.com/rust-lang/rustup/issues/3189 which is triggered on Github Actions Windows runners.