### PR TITLE
Allow finding and linking system deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Minimal builds
 The default-on `kems` and `sigs` features turn on all supported KEMs and signature schemes. If you want a smaller build, turn off these default features and opt-in to individual algorithms.
 Note that if you specify `default-features = false`, you may also want to re-include the `oqs-sys/openssl` feature.
 
+Vendored `liboqs`
+-----------------
+
+By default `oqs-sys` attempts to find a system-provided version of `liboqs` and build against it,
+falling back to vendored from-source build otherwise.
+You can opt into forcing the vendored build by enabling the `vendored` feature.
+
 Serde support
 -------------
 

--- a/oqs-sys/Cargo.toml
+++ b/oqs-sys/Cargo.toml
@@ -18,6 +18,7 @@ include = ["README.md", "build.rs", "src/**", "liboqs/.CMake/**", "liboqs/src/**
 libc = "0.2"
 
 [build-dependencies]
+pkg-config = "0.3"
 cmake = "0.1"
 bindgen = "0.68"
 build-deps = "0.1"
@@ -27,6 +28,7 @@ default = ["openssl", "kems", "sigs"]
 openssl = []
 docs = []
 non_portable = []
+vendored = []
 # algorithms: KEMs
 kems = ["classic_mceliece", "frodokem", "hqc", "kyber", "ntruprime"]
 bike = []  # BIKE is enabled by build.rs on non-windows targets

--- a/oqs/Cargo.toml
+++ b/oqs/Cargo.toml
@@ -23,6 +23,7 @@ default-features = false
 default = ["oqs-sys/openssl", "kems", "sigs", "std"]
 std = []
 non_portable = ["oqs-sys/non_portable"]
+vendored = ["oqs-sys/vendored"]
 
 # algorithms: KEMs
 kems = ["oqs-sys/kems", "classic_mceliece", "frodokem", "hqc", "kyber", "ntruprime"]


### PR DESCRIPTION
Addresses #190 

Adds necessary changes to optionally detect the system liboqs version and link to it.

To consider:

- Should there be a `vendor` feature, or can we defer to `pkg-config` crate's env var configuration (e.g. "LIBOQS_NO_PKG_CONFIG")
- Is targeting the minor version (>= `0.8.0` && < `0.9.0`) enough?

Tested this manually with a system-installed build of liboqs 0.8.0-rc1. Not sure how best to test this in CI yet.