### PR TITLE
Don't build NTRU prime if feature is not enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Cargo test
         run: cargo test
 
+      - name: Cargo test --no-default-features
+        run: cargo test --no-default-features
+
       - name: Cargo test --no-default-features --features serde,kems,sigs,std
         run: cargo test --no-default-features --features serde,kems,sigs,std --manifest-path oqs/Cargo.toml
 

--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -71,6 +71,7 @@ fn main() {
     algorithm_feature!("KEM", "frodokem");
     algorithm_feature!("KEM", "hqc");
     algorithm_feature!("KEM", "kyber");
+    algorithm_feature!("KEM", "ntruprime");
 
     // signature schemes
     algorithm_feature!("SIG", "dilithium");


### PR DESCRIPTION
This went unnoticed because it was not tested in CI

See https://github.com/open-quantum-safe/liboqs-rust/pull/180#issuecomment-1694399607