### PR TITLE
ci: Enforce conventional commit PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,23 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: build(deps)
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: build(deps)
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: build(ci)
+  groups:
+    Actions:
+      patterns:
+        - "*"

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Forces all PRs to use http://conventionalcommits.org from now on.