### PR TITLE
feat: Allow public access to bytes

### DIFF
--- a/oqs/src/macros.rs
+++ b/oqs/src/macros.rs
@@ -31,7 +31,7 @@ macro_rules! newtype_buffer {
 
         impl<'a> $name_ref<'a> {
             /// Construct a new container around this reference version
-            fn new(bytes: &'a [u8]) -> $name_ref<'a> {
+            pub fn new(bytes: &'a [u8]) -> $name_ref<'a> {
                 $name_ref { bytes }
             }
 

--- a/oqs/src/macros.rs
+++ b/oqs/src/macros.rs
@@ -10,7 +10,7 @@ macro_rules! newtype_buffer {
         #[derive(Debug, Clone, PartialEq, Eq)]
         #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
         pub struct $name {
-            bytes: Vec<u8>,
+            pub bytes: Vec<u8>,
         }
 
         impl $name {


### PR DESCRIPTION
When [building a protocol](https://github.com/Avarok-Cybersecurity/Citadel-Protocol/), we sometimes make use of generic bytes to allow variable use of subprotocols, and don't want to have to add the overhead of serialization. By allowing public access to the inner fields (whether directly or indirectly via a function), everything works.