### PR TITLE
Auto-allocate stack in runtime

### DIFF
--- a/oqs/src/kem.rs
+++ b/oqs/src/kem.rs
@@ -321,15 +321,46 @@ impl Kem {
         let mut sk = SecretKey {
             bytes: Vec::with_capacity(kem.length_secret_key),
         };
-        let status = unsafe { func(pk.bytes.as_mut_ptr(), sk.bytes.as_mut_ptr()) };
-        status_to_result(status)?;
-        // update the lengths of the vecs
-        // this is safe to do, as we have initialised them now.
-        unsafe {
-            pk.bytes.set_len(kem.length_public_key);
-            sk.bytes.set_len(kem.length_secret_key);
+
+        let pklen = kem.length_public_key;
+        let sklen = kem.length_secret_key;
+
+        #[cfg(feature = "std")]
+        {
+            // Particularly the classic McEliece kem is very stack-heavy.
+            // The reason we're using a thread is that it allows
+            // to increase stack space, on demand, in run time.
+            // Not only does this eliminate the need to set compiler options for each build;
+            // it also means we won't be holding on to memory unnecessarily in runtime.
+            let handle = std::thread::Builder::new()
+                .stack_size(16_000_000)
+                .spawn(move || {
+                    let status = unsafe { func(pk.bytes.as_mut_ptr(), sk.bytes.as_mut_ptr()) };
+                    status_to_result(status)?;
+                    // update the lengths of the vecs
+                    // this is safe to do, as we have initialised them now.
+                    unsafe {
+                        pk.bytes.set_len(pklen);
+                        sk.bytes.set_len(sklen);
+                    }
+                    Ok((pk, sk))
+                })
+                .unwrap();
+            handle.join().unwrap()
         }
-        Ok((pk, sk))
+        #[cfg(not(feature = "std"))]
+        {
+            // For embedded, something different needs to be done to spawn a new task. For now, do it inline.
+            let status = unsafe { func(pk.bytes.as_mut_ptr(), sk.bytes.as_mut_ptr()) };
+            status_to_result(status)?;
+            // update the lengths of the vecs
+            // this is safe to do, as we have initialised them now.
+            unsafe {
+                pk.bytes.set_len(pklen);
+                sk.bytes.set_len(sklen);
+            }
+            Ok((pk, sk))
+        }
     }
 
     /// Encapsulate to the provided public key


### PR DESCRIPTION
McEliece keys, in particular, take up a large amount of stack space.

Not only do we currently have to configure this manually for builds for each individual platform,
but since the stack space is set in compile time, this RAM will be held on to indefinitely,
even while no keys are being generated.

This pull request solves both issues by running the KEM key generation in a separate thread.
This allows the stack to be created in runtime, which has two benefits:

1. Compile time configuration is no longer required and
2. Rather than taking up memory for the entire duration of the runtime, it is only in use when needed.

Running as before is still supported through a feature flag.