### PR TITLE
ci: Fix OpenSSL path, add repository_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request, merge_group]
+on: [push, pull_request, merge_group, repository_dispatch]
 
 name: Continuous integration
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set OPENSSL_ROOT_DIR
         if: startsWith(matrix.os, 'macos')
-        run: echo "OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1" >> $GITHUB_ENV
+        run: echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> $GITHUB_ENV
 
       - name: Install Rust
         run: |


### PR DESCRIPTION
This PR does two things in preparation for updating to liboqs 0.12.0:

* Adds a repository_dispatch trigger to CI.
* Fixes path to OpenSSL for macos-latest in GitHub Actions.

The first two items will allow us to trigger CI from liboqs as we do for the other language wrappers and adapt to breaking changes as they occur. When I do the update to 0.12.0 I will add CI jobs that test against liboqs main to take advantage of this functionality. (Right now CI breaks with liboqs main.)