### PR TITLE
feat: Update to liboqs 0.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
           - stable
           - beta
           - nightly
+        update-liboqs:
+          - true
+          - false
     env:
       # 20 MiB stack
       RUST_MIN_STACK: 20971520
@@ -23,6 +26,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Update liboqs submodule
+        if: matrix.update-liboqs
+        run: git submodule update --remote
 
       - name: Set stack size
         if: startsWith(matrix.os, 'windows')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.10.0 (2024-12-17)
+
+- Sync with liboqs 0.12.0.
+  - New algorithms: ML-KEM (FIPS 203), ML-DSA (FIPS 204), CROSS (NIST Additional Signatures Round 1), and MAYO (NIST Additional Signatures Round 1).
+  - Updated algorithms: HQC (NIST Round 4), Falcon (Round 3, including "padded" variants).
+  - Not included from liboqs: stateful signature algorithms LMS and XMSS.
+  - New API for signing and verifying with a context string.
+
 ## oqs-sys v0.9.1
 
 * Fix pkg-config version detection (#246)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Update your `Cargo.toml` and include `oqs`:
 
 ```toml
 [dependencies]
-oqs = "0.9.0"
+oqs = "0.10.0"
 ```
 
 `oqs-sys` can be specified equivalently.
@@ -101,13 +101,14 @@ tests.
   - `frodokem`
   - `hqc`
   - `kyber`
+  - `ml_kem`
   - `ntruprime`
-  - `saber`
 - `sigs` (default): Compile with all signature schemes enabled
+  - `cross`
   - `dilithium`
   - `falcon`
-  - `picnic`
-  - `rainbow`
+  - `mayo`
+  - `ml_dsa`
   - `sphincs`: SPHINCS<sup>+</sup>
 
 ## Running

--- a/oqs-sys/Cargo.toml
+++ b/oqs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oqs-sys"
-version = "0.9.1+liboqs-0.9.0"
+version = "0.10.0+liboqs-0.12.0"
 authors = ["Thom Wiggers <thom@thomwiggers.nl>"]
 edition = "2021"
 links = "oqs"
@@ -30,17 +30,21 @@ docs = []
 non_portable = []
 vendored = []
 # algorithms: KEMs
-kems = ["classic_mceliece", "frodokem", "hqc", "kyber", "ntruprime"]
+kems = ["classic_mceliece", "frodokem", "hqc", "kyber", "ml_kem", "ntruprime"]
 bike = []  # BIKE is enabled by build.rs on non-windows targets
 classic_mceliece = []
 frodokem = []
 hqc = []
 kyber = []
+ml_kem = []
 ntruprime = []
 # algorithms: Signature schemes
-sigs = ["dilithium", "falcon", "sphincs"]
+sigs = ["cross", "dilithium", "falcon", "mayo", "ml_dsa", "sphincs"]
+cross = []
 dilithium = []
 falcon = []
+mayo = []
+ml_dsa = []
 sphincs = []
 
 [package.metadata.docs.rs]

--- a/oqs-sys/README.md
+++ b/oqs-sys/README.md
@@ -1,7 +1,7 @@
 # FFI Rust binding to [Open Quantum Safe][oqs]'s [liboqs][]
 
 [![crates.io](https://img.shields.io/crates/v/oqs-sys)](https://crates.io/crates/oqs-sys)
-[![crates.io/docs](https://img.shields.io/docsrs/oqs-sys)](https://docs.rs/oqs/0.7.1/oqs-sys/)
+[![crates.io/docs](https://img.shields.io/docsrs/oqs-sys)](https://docs.rs/oqs/latest/oqs-sys/)
 
 This crate provides the unsafe `ffi` bindings to [liboqs][].
 
@@ -16,10 +16,14 @@ This crate provides the unsafe `ffi` bindings to [liboqs][].
     * `frodokem`
     * `hqc`
     * `kyber`
+    * `ml_kem`
     * `ntruprime`
 * `sigs` (default): Compile with all signature schemes enabled
+    * `cross`
     * `dilithium`
     * `falcon`
+    * `mayo`
+    * `ml_dsa`
     * `sphincs`: SPHINCS+
 
 [oqs]: https://openquantumsafe.org

--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -68,11 +68,15 @@ fn build_from_source() -> PathBuf {
     algorithm_feature!("KEM", "frodokem");
     algorithm_feature!("KEM", "hqc");
     algorithm_feature!("KEM", "kyber");
+    algorithm_feature!("KEM", "ml_kem");
     algorithm_feature!("KEM", "ntruprime");
 
     // signature schemes
+    algorithm_feature!("SIG", "cross");
     algorithm_feature!("SIG", "dilithium");
     algorithm_feature!("SIG", "falcon");
+    algorithm_feature!("SIG", "mayo");
+    algorithm_feature!("SIG", "ml_dsa");
     algorithm_feature!("SIG", "sphincs");
 
     if cfg!(windows) {

--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-fn generate_bindings(includedir: &Path, headerfile: &str, filter: &str) {
+fn generate_bindings(includedir: &Path, headerfile: &str, allow_filter: &str, block_filter: &str) {
     let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindgen::Builder::default()
         .clang_arg(format!("-I{}", includedir.display()))
@@ -19,11 +19,14 @@ fn generate_bindings(includedir: &Path, headerfile: &str, filter: &str) {
         // Don't generate docs unless enabled
         // Otherwise it breaks tests
         .generate_comments(cfg!(feature = "docs"))
-        // Whitelist OQS stuff
+        // Allowlist/blocklist OQS stuff
         .allowlist_recursively(false)
-        .allowlist_type(filter)
-        .allowlist_function(filter)
-        .allowlist_var(filter)
+        .allowlist_type(allow_filter)
+        .allowlist_function(allow_filter)
+        .allowlist_var(allow_filter)
+        .blocklist_type(block_filter)
+        .blocklist_function(block_filter)
+        .allowlist_var(block_filter)
         // Use core and libc
         .use_core()
         .ctypes_prefix("::libc")
@@ -170,12 +173,14 @@ fn main() {
     bindgen::clang_version();
 
     let includedir = probe_includedir();
-    let gen_bindings = |file, filter| generate_bindings(&includedir, file, filter);
+    let gen_bindings = |file, allow_filter, block_filter| {
+        generate_bindings(&includedir, file, allow_filter, block_filter)
+    };
 
-    gen_bindings("common", "OQS_.*");
-    gen_bindings("rand", "OQS_(randombytes|RAND)_.*");
-    gen_bindings("kem", "OQS_KEM.*");
-    gen_bindings("sig", "OQS_SIG.*");
+    gen_bindings("common", "OQS_.*", "");
+    gen_bindings("rand", "OQS_(randombytes|RAND)_.*", "");
+    gen_bindings("kem", "OQS_KEM.*", "");
+    gen_bindings("sig", "OQS_SIG.*", "OQS_SIG_STFL.*");
 
     // https://docs.rs/build-deps/0.1.4/build_deps/fn.rerun_if_changed_paths.html
     build_deps::rerun_if_changed_paths("liboqs/src/**/*").unwrap();

--- a/oqs/Cargo.toml
+++ b/oqs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oqs"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Thom Wiggers <thom@thomwiggers.nl>"]
 edition = "2021"
 description = "A Rusty interface to Open-Quantum-Safe's liboqs"
@@ -16,7 +16,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 
 [dependencies.oqs-sys]
 path = "../oqs-sys"
-version = "0.9.0"
+version = "0.10.0"
 default-features = false
 
 [features]
@@ -26,15 +26,19 @@ non_portable = ["oqs-sys/non_portable"]
 vendored = ["oqs-sys/vendored"]
 
 # algorithms: KEMs
-kems = ["oqs-sys/kems", "classic_mceliece", "frodokem", "hqc", "kyber", "ntruprime"]
+kems = ["oqs-sys/kems", "classic_mceliece", "frodokem", "hqc", "kyber", "ml_kem", "ntruprime"]
 bike = ["oqs-sys/bike"]  # not supported on Windows or 32-bit ARM
 classic_mceliece = ["oqs-sys/classic_mceliece"]
 frodokem = ["oqs-sys/frodokem"]
 hqc = ["oqs-sys/hqc"]
 kyber = ["oqs-sys/kyber"]
+ml_kem = ["oqs-sys/ml_kem"]
 ntruprime = ["oqs-sys/ntruprime"]
 # algorithms: Signature schemes
-sigs = ["oqs-sys/sigs", "dilithium", "falcon", "sphincs"]
+sigs = ["oqs-sys/sigs", "cross", "dilithium", "falcon", "mayo", "ml_dsa", "sphincs"]
+cross = ["oqs-sys/cross"]
 dilithium = ["oqs-sys/dilithium"]
 falcon = ["oqs-sys/falcon"]
+mayo = ["oqs-sys/mayo"]
+ml_dsa = ["oqs-sys/ml_dsa"]
 sphincs = ["oqs-sys/sphincs"]

--- a/oqs/README.md
+++ b/oqs/README.md
@@ -1,7 +1,7 @@
 # Bindings to Open-Quantum-Safe's [liboqs][]
 
 [![crates.io](https://img.shields.io/crates/v/oqs)](https://crates.io/crates/oqs)
-[![crates.io/docs](https://img.shields.io/docsrs/oqs)](https://docs.rs/oqs/0.7.1/oqs/)
+[![crates.io/docs](https://img.shields.io/docsrs/oqs)](https://docs.rs/oqs/latest/oqs/)
 
 This crate provides convenience wrappers to access the functionality provided by [liboqs][].
 For the ``ffi`` interface bindings, see ``oqs-sys``.
@@ -21,8 +21,12 @@ For the ``ffi`` interface bindings, see ``oqs-sys``.
   * `frodokem`
   * `hqc`
   * `kyber`
+  * `ml_kem`
   * `ntruprime`
 * `sigs` (default): Compile with all signature schemes enabled
+  * `cross`
   * `dilithium`
   * `falcon`
+  * `mayo`
+  * `ml_dsa`
   * `sphincs`: SPHINCS+

--- a/oqs/src/kem.rs
+++ b/oqs/src/kem.rs
@@ -133,6 +133,9 @@ implement_kems! {
     ("kyber") Kyber512: OQS_KEM_alg_kyber_512,
     ("kyber") Kyber768: OQS_KEM_alg_kyber_768,
     ("kyber") Kyber1024: OQS_KEM_alg_kyber_1024,
+    ("ml_kem") MlKem512: OQS_KEM_alg_ml_kem_512,
+    ("ml_kem") MlKem768: OQS_KEM_alg_ml_kem_768,
+    ("ml_kem") MlKem1024: OQS_KEM_alg_ml_kem_1024,
     ("ntruprime") NtruPrimeSntrup761: OQS_KEM_alg_ntruprime_sntrup761,
     ("frodokem") FrodoKem640Aes: OQS_KEM_alg_frodokem_640_aes,
     ("frodokem") FrodoKem640Shake: OQS_KEM_alg_frodokem_640_shake,
@@ -177,10 +180,10 @@ impl std::fmt::Display for Algorithm {
 ///
 /// # Example
 /// ```rust
-/// # if !cfg!(feature = "kyber") { return; }
+/// # if !cfg!(feature = "ml_kem") { return; }
 /// use oqs;
 /// oqs::init();
-/// let kem = oqs::kem::Kem::new(oqs::kem::Algorithm::Kyber512).unwrap();
+/// let kem = oqs::kem::Kem::new(oqs::kem::Algorithm::MlKem512).unwrap();
 /// let (pk, sk) = kem.keypair().unwrap();
 /// let (ct, ss) = kem.encapsulate(&pk).unwrap();
 /// let ss2 = kem.decapsulate(&sk, &ct).unwrap();

--- a/oqs/src/lib.rs
+++ b/oqs/src/lib.rs
@@ -9,11 +9,11 @@
 //! This protocol has no replay protection!
 //! ```
 //! use oqs::*;
-//! # #[cfg(all(feature = "dilithium2", feature = "kyber"))]
+//! # #[cfg(all(feature = "ml_dsa", feature = "ml_kem"))]
 //! fn main() -> Result<()> {
 //!     oqs::init(); // Important: initialize liboqs
-//!     let sigalg = sig::Sig::new(sig::Algorithm::Dilithium2)?;
-//!     let kemalg = kem::Kem::new(kem::Algorithm::Kyber512)?;
+//!     let sigalg = sig::Sig::new(sig::Algorithm::MlDsa44)?;
+//!     let kemalg = kem::Kem::new(kem::Algorithm::MlKem512)?;
 //!     // A's long-term secrets
 //!     let (a_sig_pk, a_sig_sk) = sigalg.keypair()?;
 //!     // B's long-term secrets
@@ -38,7 +38,7 @@
 //!
 //!     Ok(())
 //! }
-//! # #[cfg(not(all(feature = "dilithium2", feature = "kyber")))]
+//! # #[cfg(not(all(feature = "ml_dsa", feature = "ml_kem")))]
 //! # fn main() {}
 //! ```
 // needs to be imported to be made available

--- a/oqs/src/sig.rs
+++ b/oqs/src/sig.rs
@@ -114,11 +114,36 @@ macro_rules! implement_sigs {
 }
 
 implement_sigs! {
+    ("cross") CrossRsdp128Balanced: OQS_SIG_alg_cross_rsdp_128_balanced,
+    ("cross") CrossRsdp128Fast: OQS_SIG_alg_cross_rsdp_128_fast,
+    ("cross") CrossRsdp128Small: OQS_SIG_alg_cross_rsdp_128_small,
+    ("cross") CrossRsdp192Balanced: OQS_SIG_alg_cross_rsdp_192_balanced,
+    ("cross") CrossRsdp192Fast: OQS_SIG_alg_cross_rsdp_192_fast,
+    ("cross") CrossRsdp192Small: OQS_SIG_alg_cross_rsdp_192_small,
+    ("cross") CrossRsdp256Balanced: OQS_SIG_alg_cross_rsdp_256_balanced,
+    ("cross") CrossRsdp256Fast: OQS_SIG_alg_cross_rsdp_256_fast,
+    ("cross") CrossRsdp256Small: OQS_SIG_alg_cross_rsdp_256_small,
+    ("cross") CrossRsdpg128Balanced: OQS_SIG_alg_cross_rsdpg_128_balanced,
+    ("cross") CrossRsdpg128Fast: OQS_SIG_alg_cross_rsdpg_128_fast,
+    ("cross") CrossRsdpg128Small: OQS_SIG_alg_cross_rsdpg_128_small,
+    ("cross") CrossRsdpg192Balanced: OQS_SIG_alg_cross_rsdpg_192_balanced,
+    ("cross") CrossRsdpg192Fast: OQS_SIG_alg_cross_rsdpg_192_fast,
+    ("cross") CrossRsdpg192Small: OQS_SIG_alg_cross_rsdpg_192_small,
+    ("cross") CrossRsdpg256Balanced: OQS_SIG_alg_cross_rsdpg_256_balanced,
+    ("cross") CrossRsdpg256Fast: OQS_SIG_alg_cross_rsdpg_256_fast,
+    ("cross") CrossRsdpg256Small: OQS_SIG_alg_cross_rsdpg_256_small,
     ("dilithium") Dilithium2: OQS_SIG_alg_dilithium_2,
     ("dilithium") Dilithium3: OQS_SIG_alg_dilithium_3,
     ("dilithium") Dilithium5: OQS_SIG_alg_dilithium_5,
     ("falcon") Falcon512: OQS_SIG_alg_falcon_512,
     ("falcon") Falcon1024: OQS_SIG_alg_falcon_1024,
+    ("mayo") Mayo1: OQS_SIG_alg_mayo_1,
+    ("mayo") Mayo2: OQS_SIG_alg_mayo_2,
+    ("mayo") Mayo3: OQS_SIG_alg_mayo_3,
+    ("mayo") Mayo5: OQS_SIG_alg_mayo_5,
+    ("ml_dsa") MlDsa44: OQS_SIG_alg_ml_dsa_44,
+    ("ml_dsa") MlDsa65: OQS_SIG_alg_ml_dsa_65,
+    ("ml_dsa") MlDsa87: OQS_SIG_alg_ml_dsa_87,
     ("sphincs") SphincsSha2128fSimple: OQS_SIG_alg_sphincs_sha2_128f_simple,
     ("sphincs") SphincsSha2128sSimple: OQS_SIG_alg_sphincs_sha2_128s_simple,
     ("sphincs") SphincsSha2192fSimple: OQS_SIG_alg_sphincs_sha2_192f_simple,
@@ -161,10 +186,10 @@ impl Algorithm {
 ///
 /// # Example
 /// ```rust
-/// # if !cfg!(feature = "dilithium") { return; }
+/// # if !cfg!(feature = "ml_dsa") { return; }
 /// use oqs;
 /// oqs::init();
-/// let scheme = oqs::sig::Sig::new(oqs::sig::Algorithm::Dilithium2).unwrap();
+/// let scheme = oqs::sig::Sig::new(oqs::sig::Algorithm::MlDsa44).unwrap();
 /// let message = [0u8; 100];
 /// let (pk, sk) = scheme.keypair().unwrap();
 /// let signature = scheme.sign(&message, &sk).unwrap();


### PR DESCRIPTION
This PR brings liboqs-rust in sync with liboqs version 0.12.0. Notably, this includes
- additions of ML-KEM, ML-DSA, MAYO, and CROSS
- updates to HQC and Falcon
- new signature APIs for signing and verifying with a context string.

Since liboqs 0.12.0 was just released, this PR also brings liboqs-rust in sync with the liboqs main branch. With an eye to keeping it that way, I added CI runs which build and test against liboqs main.

https://github.com/open-quantum-safe/liboqs-rust/pull/271 should be merged first.