### PR TITLE
fix: run install target during build

### DIFF
--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -119,7 +119,10 @@ fn build_from_source() -> PathBuf {
     // remove the build folder
     let temp_build = outdir.join("build");
     if let Err(e) = std::fs::remove_dir_all(temp_build) {
-        println!("cargo:warning=unexpected error while cleaning build files:{}", e);
+        println!(
+            "cargo:warning=unexpected error while cleaning build files:{}",
+            e
+        );
     }
 
     // lib is installed to $outdir/lib

--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -113,10 +113,17 @@ fn build_from_source() -> PathBuf {
         config.define(permit_unsupported, str);
     }
 
-    let outdir = config.build_target("oqs").build();
+    // build the default (install) target.
+    let outdir = config.build();
 
-    // lib is put into $outdir/build/lib
-    let mut libdir = outdir.join("build").join("lib");
+    // remove the build folder
+    let temp_build = outdir.join("build");
+    if let Err(e) = std::fs::remove_dir_all(temp_build) {
+        println!("cargo:warning=unexpected error while cleaning build files:{}", e);
+    }
+
+    // lib is installed to $outdir/lib
+    let mut libdir = outdir.join("lib");
     if cfg!(windows) {
         libdir.push("Release");
         // Static linking doesn't work on Windows
@@ -132,7 +139,7 @@ fn build_from_source() -> PathBuf {
 
 fn includedir_from_source() -> PathBuf {
     let outdir = build_from_source();
-    outdir.join("build").join("include")
+    outdir.join("include")
 }
 
 fn probe_includedir() -> PathBuf {

--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -123,9 +123,8 @@ fn build_from_source() -> PathBuf {
     }
 
     // lib is installed to $outdir/lib
-    let mut libdir = outdir.join("lib");
+    let libdir = outdir.join("lib");
     if cfg!(windows) {
-        libdir.push("Release");
         // Static linking doesn't work on Windows
         println!("cargo:rustc-link-lib=oqs");
     } else {


### PR DESCRIPTION
Currently, the build script will only compile the `oqs` target. This means that the cmake package config file is not generated. This means that the vendored CMake project can't be easily used as a dependency of a different CMake project.

This PR changes the behavior to build and execute the `install` target. I also remove the "build" folder to keep things a bit neater. 

### Current Behavior
```
/home/ubuntu/workspace/liboqs-rust/target/debug/build/oqs-sys-71d0b41005a2adce/out
├── build
│   ├── CMakeCache.txt
│   ├── CMakeFiles
│   │   └── <SNIP, lots of cmake stuff but NOT the config file>
│   ├── CPackConfig.cmake
│   ├── CPackSourceConfig.cmake
│   ├── Makefile
│   ├── cmake_install.cmake
│   ├── cmake_uninstall.cmake
│   ├── compile_commands.json
│   ├── include
│   │   └── oqs
│   ├── lib
│   │   └── liboqs.a
│   └── src
│       ├── CMakeFiles
│       ├── Makefile
│       ├── cmake
│       ├── cmake_install.cmake
│       ├── common
│       ├── kem
│       ├── liboqs.pc
│       ├── liboqsConfig.cmake
│       ├── liboqsConfigVersion.cmake
│       └── sig
├── common_bindings.rs
├── kem_bindings.rs
├── rand_bindings.rs
└── sig_bindings.rs
```

### Proposed Behavior
```
/home/ubuntu/workspace/liboqs-rust/target/debug/build/oqs-sys-71d0b41005a2adce/out
├── common_bindings.rs
├── include
│   └── oqs
│       ├── aes_ops.h
│       ├── common.h
│       ├── kem.h
│       ├── kem_bike.h
│       └── <SNIP, you get the idea>
├── kem_bindings.rs
├── lib
│   ├── cmake
│   │   └── liboqs
│   │       ├── liboqsConfig.cmake
│   │       ├── liboqsConfigVersion.cmake
│   │       ├── liboqsTargets-release.cmake
│   │       └── liboqsTargets.cmake
│   ├── liboqs.a
│   └── pkgconfig
│       └── liboqs.pc
├── rand_bindings.rs
└── sig_bindings.rs
```

### Testing
All unit tests pass on my platform, and I am able to vendor the oqs-provider artifact from my own rust crate with this change.