### PR TITLE
feat: consume openssl from openssl-sys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,10 @@ jobs:
       - name: Cargo test --no-default-features --features non_portable,kems,sigs,std
         run: cargo test --no-default-features --features non_portable,kems,sigs,std --manifest-path oqs/Cargo.toml
 
+      # skip windows, because the default image doesn't include several of the
+      # system dependencies (e.g. Perl) required for the openssl-sys/vendored
       - name: Cargo test --features vendored_openssl
+        if: matrix.os != 'windows-latest'
         run: cargo test --features vendored_openssl --manifest-path oqs/Cargo.toml
 
       - name: Cargo fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Cargo test --no-default-features --features non_portable,kems,sigs,std
         run: cargo test --no-default-features --features non_portable,kems,sigs,std --manifest-path oqs/Cargo.toml
 
+      - name: Cargo test --features vendored_openssl
+        run: cargo test --features vendored_openssl --manifest-path oqs/Cargo.toml
+
       - name: Cargo fmt
         run: cargo fmt --all -- --check
 

--- a/oqs-sys/Cargo.toml
+++ b/oqs-sys/Cargo.toml
@@ -16,6 +16,7 @@ include = ["README.md", "build.rs", "src/**", "liboqs/.CMake/**", "liboqs/src/**
 
 [dependencies]
 libc = "0.2"
+openssl-sys = { version = "0.9", optional = true }
 
 [build-dependencies]
 pkg-config = "0.3"
@@ -25,7 +26,7 @@ build-deps = "0.1"
 
 [features]
 default = ["openssl", "kems", "sigs"]
-openssl = []
+openssl = ["dep:openssl-sys"]
 docs = []
 non_portable = []
 vendored = []

--- a/oqs-sys/Cargo.toml
+++ b/oqs-sys/Cargo.toml
@@ -16,7 +16,7 @@ include = ["README.md", "build.rs", "src/**", "liboqs/.CMake/**", "liboqs/src/**
 
 [dependencies]
 libc = "0.2"
-openssl-sys = { version = "0.9", optional = true }
+openssl-sys = { version = "0.9", features = ["vendored"], optional = true }
 
 [build-dependencies]
 pkg-config = "0.3"
@@ -26,7 +26,8 @@ build-deps = "0.1"
 
 [features]
 default = ["openssl", "kems", "sigs"]
-openssl = ["dep:openssl-sys"]
+openssl = []
+vendored_openssl = ["openssl", "vendored", "dep:openssl-sys"]
 docs = []
 non_portable = []
 vendored = []

--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -88,15 +88,8 @@ fn build_from_source() -> PathBuf {
         config.define("CMAKE_SYSTEM_VERSION", "10.0");
     }
 
-    if cfg!(feature = "vendored_openssl") {
-        // DEP_OPENSSL_ROOT is set by openssl-sys if a vendored build was used.
-        // We point CMake towards this so that the vendored openssl is preferred
-        // over the system openssl.
-        let vendored_openssl_root = std::env::var("DEP_OPENSSL_ROOT")
-            .expect("The `vendored_openssl` feature was enabled, but DEP_OPENSSL_ROOT was not set");
-        config.define("OQS_USE_OPENSSL", "Yes");
-        config.define("OPENSSL_ROOT_DIR", vendored_openssl_root);
-    } else if cfg!(feature = "openssl") {
+    // link the openssl libcrypto
+    if cfg!(any(feature = "openssl", feature = "vendored_openssl")) {
         config.define("OQS_USE_OPENSSL", "Yes");
         if cfg!(windows) {
             // Windows doesn't prefix with lib
@@ -104,7 +97,19 @@ fn build_from_source() -> PathBuf {
         } else {
             println!("cargo:rustc-link-lib=crypto");
         }
+    } else {
+        config.define("OQS_USE_OPENSSL", "No");
+    }
 
+    // let the linker know where to search for openssl libcrypto
+    if cfg!(feature = "vendored_openssl") {
+        // DEP_OPENSSL_ROOT is set by openssl-sys if a vendored build was used.
+        // We point CMake towards this so that the vendored openssl is preferred
+        // over the system openssl.
+        let vendored_openssl_root = std::env::var("DEP_OPENSSL_ROOT")
+            .expect("The `vendored_openssl` feature was enabled, but DEP_OPENSSL_ROOT was not set");
+        config.define("OPENSSL_ROOT_DIR", vendored_openssl_root);
+    } else if cfg!(feature = "openssl") {
         println!("cargo:rerun-if-env-changed=OPENSSL_ROOT_DIR");
         if let Ok(dir) = std::env::var("OPENSSL_ROOT_DIR") {
             let dir = Path::new(&dir).join("lib");
@@ -112,8 +117,6 @@ fn build_from_source() -> PathBuf {
         } else if cfg!(target_os = "windows") || cfg!(target_os = "macos") {
             println!("cargo:warning=You may need to specify OPENSSL_ROOT_DIR or disable the default `openssl` feature.");
         }
-    } else {
-        config.define("OQS_USE_OPENSSL", "No");
     }
 
     let permit_unsupported = "OQS_PERMIT_UNSUPPORTED_ARCHITECTURE";

--- a/oqs/Cargo.toml
+++ b/oqs/Cargo.toml
@@ -24,6 +24,7 @@ default = ["oqs-sys/openssl", "kems", "sigs", "std"]
 std = []
 non_portable = ["oqs-sys/non_portable"]
 vendored = ["oqs-sys/vendored"]
+vendored_openssl = ["oqs-sys/vendored_openssl"]
 
 # algorithms: KEMs
 kems = ["oqs-sys/kems", "classic_mceliece", "frodokem", "hqc", "kyber", "ml_kem", "ntruprime"]


### PR DESCRIPTION
Allow liboqs-rust to use the OpenSSL pulled in from `openssl-sys`.

If a rust project wants to link several things against OpenSSL, it is easiest to use the standard `openssl-sys` package. This PR adds a new feature `vendored_openssl` that will allow the vendored_openssl to be pulled in.

## Callouts

I added this as a totally separate feature, which preserves the current `OPENSSL_ROOT_DIR` environment variable behavior. `openssl-sys` expects openssl to be specified with `OPENSSL_DIR`, so it would be a breaking change.

Alternately this "feature" could be the result if enabled both `openssl` and `vendored`. E.g., if you want a vendored liboqs then you might also want a vendored openssl?