### PR TITLE
fix: block filter added to block list, not allow list

### DIFF
--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -26,7 +26,7 @@ fn generate_bindings(includedir: &Path, headerfile: &str, allow_filter: &str, bl
         .allowlist_var(allow_filter)
         .blocklist_type(block_filter)
         .blocklist_function(block_filter)
-        .allowlist_var(block_filter)
+        .blocklist_var(block_filter)
         // Use core and libc
         .use_core()
         .ctypes_prefix("::libc")


### PR DESCRIPTION
This fixes a bug in the build script where a block filter is being added to the allow list instead of the block list.