### PR TITLE
ci: Disable nightly builds on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         update-liboqs:
           - true
           - false
+        exclude:
+          - os: windows-latest
+            rust: nightly
     env:
       # 20 MiB stack
       RUST_MIN_STACK: 20971520


### PR DESCRIPTION
Recently, CI has been failing on Windows with Nightly Rust. CI is passing on all other configurations, including Windows with Beta Rust. This PR disables the Nightly Rust builds. As far as I can tell, this issue is not related to a change in liboqs or liboqs-rust.

I will periodically try re-enabling the Nightly build to see if the issue resolves itself. In the meantime, if somebody with more Rust knowledge has a fix, please feel to submit it!