### PR TITLE
ci: exclude Windows / Beta Rust from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         exclude:
           - os: windows-latest
             rust: nightly
+          - os: windows-latest
+            rust: beta
     env:
       # 20 MiB stack
       RUST_MIN_STACK: 20971520


### PR DESCRIPTION
I guess that whatever changed in Nightly Rust has now made its way into Beta Rust. See https://github.com/open-quantum-safe/liboqs-rust/pull/282.