### PR TITLE
fix: Explicitly link against advapi32 on Windows, reactivate Windows Nightly and Beta builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
         exclude:
           - os: windows-latest
             rust: nightly
-          - os: windows-latest
-            rust: beta
     env:
       # 20 MiB stack
       RUST_MIN_STACK: 20971520

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
         update-liboqs:
           - true
           - false
-        exclude:
-          - os: windows-latest
-            rust: nightly
     env:
       # 20 MiB stack
       RUST_MIN_STACK: 20971520

--- a/oqs-sys/build.rs
+++ b/oqs-sys/build.rs
@@ -147,6 +147,12 @@ fn build_from_source() -> PathBuf {
         // Statically linking makes it easier to use the sys crate
         println!("cargo:rustc-link-lib=static=oqs");
     }
+
+    if cfg!(windows) {
+        // Explicitly link against advapi32. See https://github.com/rust-lang/rust/issues/140555
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+
     println!("cargo:rustc-link-search=native={}", libdir.display());
     println!("cargo:rustc-link-search=native={}", libdir64.display());
 


### PR DESCRIPTION
Fixes #283. See https://github.com/rust-lang/rust/issues/140555.