### PR TITLE
feat: implement FromStr for Algorithm Enums

### DIFF
--- a/oqs/src/kem.rs
+++ b/oqs/src/kem.rs
@@ -5,6 +5,7 @@
 use alloc::vec::Vec;
 
 use core::ptr::NonNull;
+use core::str::FromStr;
 
 #[cfg(not(feature = "std"))]
 use cstr_core::CStr;
@@ -48,6 +49,19 @@ macro_rules! implement_kems {
                 )*
             };
             id as *const _ as *const libc::c_char
+        }
+
+        impl FromStr for Algorithm {
+            type Err = crate::Error;
+
+            fn from_str(s: &str) -> Result<Self> {
+                $(
+                    if s == Algorithm::$kem.name() {
+                        return Ok(Algorithm::$kem);
+                    }
+                )*
+                Err(crate::Error::AlgorithmParsingError)
+            }
         }
 
         $(
@@ -138,6 +152,14 @@ macro_rules! implement_kems {
                         // ... And actually contains something.
                         assert!(!version.is_empty());
                     }
+                }
+
+                #[test]
+                fn test_from_str() {
+                    let algorithm = Algorithm::$kem;
+                    let name = algorithm.name();
+                    let parsed = Algorithm::from_str(name).unwrap();
+                    assert_eq!(algorithm, parsed);
                 }
             }
         )*

--- a/oqs/src/lib.rs
+++ b/oqs/src/lib.rs
@@ -89,6 +89,8 @@ pub enum Error {
     ErrorExternalOpenSSL,
     /// Invalid length of a public object
     InvalidLength,
+    /// Error while trying to parse string to an algorithm
+    AlgorithmParsingError,
 }
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}

--- a/oqs/src/sig.rs
+++ b/oqs/src/sig.rs
@@ -5,6 +5,7 @@
 use alloc::vec::Vec;
 
 use core::ptr::{null, NonNull};
+use core::str::FromStr;
 
 #[cfg(not(feature = "std"))]
 use cstr_core::CStr;
@@ -50,6 +51,19 @@ macro_rules! implement_sigs {
                 )*
             };
             id as *const _ as *const libc::c_char
+        }
+
+        impl FromStr for Algorithm {
+            type Err = crate::Error;
+
+            fn from_str(s: &str) -> Result<Self> {
+                $(
+                    if s == Algorithm::$sig.name() {
+                        return Ok(Algorithm::$sig);
+                    }
+                )*
+                Err(crate::Error::AlgorithmParsingError)
+            }
         }
 
         $(
@@ -157,6 +171,13 @@ macro_rules! implement_sigs {
                         assert!(!version.is_empty());
                     }
                 }
+
+                #[test]
+                fn test_from_str() {
+                    let algorithm = Algorithm::$sig;
+                    let name = algorithm.name();
+                    let parsed = Algorithm::from_str(name).unwrap();
+                    assert_eq!(algorithm, parsed);}
             }
         )*
     )


### PR DESCRIPTION
This adds a `FromStr` implementation for `oqs::kem::Algorithm` and `oqs::sig::Algorithm`.
The strings returned from the `name` method can now be converted back into the specific enum variant.

This PR solves #290 