### PR TITLE
feat:  Implemented the RustCrypto traits for signatures and kems (#137)

### DIFF
--- a/oqs/Cargo.toml
+++ b/oqs/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT OR Apache-2.0"
 libc = "0.2"
 cstr_core = { version = "0.2", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive", "alloc"] }
+kem = "=0.3.0-pre.0"
+signature = "2.2.0"
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [dependencies.oqs-sys]
 path = "../oqs-sys"


### PR DESCRIPTION
This adds structs Encapsulator and Decacpsulator that implement the RustCrypto traits kem::Encapsulate and kem::Decapsulate, as well as Signer and Verifier that implement signature::Signer and signature::Verifier.

Note that I used version v0.3.0-pre.0 of RustCrypto's KEM trait, and not v0.2.0. The newer traits are much nicer to work with and in particular, don't require to manually define extra types for ciphertext size and shared secret size of each individual KEM. See [this issue](https://github.com/RustCrypto/traits/pull/1509) for a more detailed discussion.


This is my first PR in this project, so please let me know if anything is off.
I read [CONTRIBUTING.md](https://github.com/open-quantum-safe/liboqs-rust/blob/main/CONTRIBUTING.md) and [README.md](https://github.com/open-quantum-safe/liboqs-rust/blob/main/README.md).
