### PR TITLE
fix: support compiling on Windows ARM64

### DIFF
--- a/oqs/src/kem.rs
+++ b/oqs/src/kem.rs
@@ -217,7 +217,7 @@ impl Algorithm {
     /// This is the same as the `to_id`, but as a safe Rust string.
     pub fn name(&self) -> &'static str {
         // SAFETY: The id from ffi must be a proper null terminated C string
-        let id = unsafe { CStr::from_ptr(self.to_id()) };
+        let id = unsafe { CStr::from_ptr(self.to_id() as *const _) };
         id.to_str().expect("OQS algorithm names must be UTF-8")
     }
 }
@@ -282,7 +282,7 @@ impl Kem {
     pub fn version(&self) -> &'static str {
         let kem = unsafe { self.kem.as_ref() };
         // SAFETY: The alg_version from ffi must be a proper null terminated C string
-        let cstr = unsafe { CStr::from_ptr(kem.alg_version) };
+        let cstr = unsafe { CStr::from_ptr(kem.alg_version as *const _) };
         cstr.to_str()
             .expect("Algorithm version strings must be UTF-8")
     }

--- a/oqs/src/sig.rs
+++ b/oqs/src/sig.rs
@@ -259,7 +259,7 @@ impl Algorithm {
     /// This is the same as the `to_id`, but as a safe Rust string.
     pub fn name(&self) -> &'static str {
         // SAFETY: The id from ffi must be a proper null terminated C string
-        let id = unsafe { CStr::from_ptr(self.to_id()) };
+        let id = unsafe { CStr::from_ptr(self.to_id() as *const _) };
         id.to_str().expect("OQS algorithm names must be UTF-8")
     }
 }
@@ -326,7 +326,7 @@ impl Sig {
     pub fn version(&self) -> &'static str {
         let sig = unsafe { self.sig.as_ref() };
         // SAFETY: The alg_version from ffi must be a proper null terminated C string
-        let cstr = unsafe { CStr::from_ptr(sig.alg_version) };
+        let cstr = unsafe { CStr::from_ptr(sig.alg_version as *const _) };
         cstr.to_str()
             .expect("Algorithm version strings must be UTF-8")
     }


### PR DESCRIPTION
`libc::c_char` in Rust differs by target architecture:
- On most platforms (x86-64 Windows, Linux, macOS) it is `i8`.
- On Windows ARM64 (AArch64) it is `u8`.

This change unconditionally casts pointers with `as *const _`:
- On Windows ARM64, this converts `*const i8` to `*const u8` (or vice versa), resolving the type mismatch that caused compilation to fail.
- On other platforms, the cast is effectively a no-op but ensures the code compiles everywhere.

`CStr::from_ptr` only requires a pointer to a null-terminated byte sequence. The underlying representation of `i8` and `u8` is identical, so the cast is sound.

This change allows building and running on Windows ARM (yes, under `OQS_PERMIT_UNSUPPORTED_ARCHITECTURE`)

By the way - Windows on arm Github Agents are available for free now, so it might be nice to extend the CI setup with that https://github.com/orgs/community/discussions/155713.